### PR TITLE
WIIS-9882

### DIFF
--- a/src/Repository/IOT/SensorWrapperRepository.php
+++ b/src/Repository/IOT/SensorWrapperRepository.php
@@ -65,6 +65,10 @@ class SensorWrapperRepository extends EntityRepository
                                 ->leftJoin('sensor_wrapper.sensor', 'order_sensor')
                                 ->orderBy('order_sensor.code', $order);
                             break;
+                        case 'name':
+                            $qb
+                                ->orderBy('sensor_wrapper.name', $order);
+                            break;
                         case 'battery':
                             $qb
                                 ->leftJoin('sensor_wrapper.sensor', 'order_sensor')


### PR DESCRIPTION
IOT I Capteurs - Impossible de trier par le nom du capteur dans Follow