### PR TITLE
WIIS-10459

### DIFF
--- a/src/Repository/EmplacementRepository.php
+++ b/src/Repository/EmplacementRepository.php
@@ -152,8 +152,7 @@ class EmplacementRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findByParamsAndExcludeInactive(InputBag $params = null, $excludeInactive = false)
-    {
+    public function findByParamsAndExcludeInactive(InputBag $params = null, $excludeInactive = false): array {
         $countTotal = $this->countAll();
 
         $queryBuilder = $this->createQueryBuilder('location');
@@ -202,10 +201,6 @@ class EmplacementRepository extends EntityRepository
                 }
             }
             $queryBuilder->select('count(location)');
-            $countQuery = (int) $queryBuilder->getQuery()->getSingleScalarResult();
-        }
-        else {
-            $countQuery = $countTotal;
         }
 
         $queryBuilder
@@ -215,8 +210,10 @@ class EmplacementRepository extends EntityRepository
         if ($params->getInt('length')) $queryBuilder->setMaxResults($params->getInt('length'));
 
         $query = $queryBuilder->getQuery();
+        $data = $query?->getResult();
+        $countQuery = sizeof($data);
         return [
-            'data' => $query ? $query->getResult() : null,
+            'data' => $data,
             'allEmplacementDataTable' => !empty($params) ? $query->getResult() : null,
             'count' => $countQuery,
             'total' => $countTotal


### PR DESCRIPTION
Référentiel I Emplacements I bug affichage

J’ai cherché dans les emplacements avec le mot clé “pompe” et j’ai 2 pages de résultat alors qu’il n’y a que 4 emplacements sélectionnés. Le dernier emplacement est affiché sur la page 1 et 2

