### PR TITLE
WIIS-11216

### DIFF
--- a/src/Controller/Kiosk/KioskController.php
+++ b/src/Controller/Kiosk/KioskController.php
@@ -76,7 +76,7 @@ class KioskController extends AbstractController
         if (str_starts_with($scannedReference, 'ART')) {
             $article = $articleRepository->findOneBy(['barCode' => $scannedReference]);
             $reference = $article->getArticleFournisseur()->getReferenceArticle();
-        } else {
+        } else if ($scannedReference){
             $reference = $referenceArticleRepository->findOneBy(['barCode' => $scannedReference])
                 ?? $referenceArticleRepository->findOneBy(['reference' => $scannedReference])
                 ?? new ReferenceArticle();
@@ -86,7 +86,10 @@ class KioskController extends AbstractController
             } else {
                 $article = null;
             }
+        } else {
+            $reference = new ReferenceArticle();
         }
+
         $freeField = $settingRepository->getOneParamByLabel(Setting::FREE_FIELD_REFERENCE_CREATE) ? $freeFieldRepository->find($settingRepository->getOneParamByLabel(Setting::FREE_FIELD_REFERENCE_CREATE)) : '';
         return $this->render('kiosk/form.html.twig', [
             'reference' => $reference,

--- a/src/Controller/ReferenceArticleController.php
+++ b/src/Controller/ReferenceArticleController.php
@@ -1076,6 +1076,7 @@ class ReferenceArticleController extends AbstractController
                 ->setLibelle($data['label'])
                 ->setCreatedBy($userRepository->getKioskUser())
                 ->setCreatedAt(new DateTime())
+                ->setBarCode($refArticleDataService->generateBarCode())
                 ->setStatut($status)
                 ->setType($type)
                 ->setTypeQuantite(ReferenceArticle::QUANTITY_TYPE_ARTICLE);;


### PR DESCRIPTION
WEB I BORNE I 2 bugs

- Lorsqu’on clique sur “Faire une entrée manuelle”, on a par défaut la dernière référence saisie qui n’a pas de code barre - condition à supprimer pour laisser le champs “Référence” & “Libellé” vides à chaque saisie de nouvelle référence

- Pour toute nouvelle référence créé par la borne, créer également le code barre. Aujourd’hui, le code barre est “Non défini”